### PR TITLE
Changing repo of TaskItShell to the new one

### DIFF
--- a/src/BaselineOfScale.package/BaselineOfScale.class/instance/baseline..st
+++ b/src/BaselineOfScale.package/BaselineOfScale.class/instance/baseline..st
@@ -6,19 +6,19 @@ baseline: spec
 		do: [ spec blessing: #baseline.
 			spec
 				baseline: 'TaskItShell'
-				with: [ spec repository: 'github://sbragagnolo/taskit:v1.0.1' ].
+				with: [ spec repository: 'github://pharo-contributions/taskit-shell' ].
 			spec package: #Scale ].
 	spec
 		for: #'pharo8.x'
 		do: [ spec blessing: #baseline.
 			spec
 				baseline: 'TaskItShell'
-				with: [ spec repository: 'github://sbragagnolo/taskit:master' ].
+				with: [ spec repository: 'github://pharo-contributions/taskit-shell' ].
 			spec package: #Scale ].
 	spec
 		for: #'pharo9.x'
 		do: [ spec blessing: #baseline.
 			spec
 				baseline: 'TaskItShell'
-				with: [ spec repository: 'github://sbragagnolo/taskit:master' ].
+				with: [ spec repository: 'github://pharo-contributions/taskit-shell' ].
 			spec package: #Scale ]


### PR DESCRIPTION
Scale had an old reference to TaskItShell which was once part of TaskIt, but which have recently been broken out into its own repository.